### PR TITLE
Use Kohirens Alpine GLibC As Base Image

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,45 @@
+{{ if .Unreleased -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .UnreleasedHash.Short }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ .UnreleasedHash.Short }}...HEAD
+{{ end -}}
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ end -}}
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,35 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/kohirens/docker-circleci-aws-iac-tf
+options:
+  commits:
+    filters:
+      Type:
+        - add
+        - fix
+        - dep
+        - chg
+        - rmv
+        - mnt
+        - doc
+        - ci
+  commit_groups:
+    title_maps:
+      add: Added
+      fix: Fixed
+      dep: Deprecated
+      chg: Changed
+      rmv: Removed
+      mnt: Maintenance
+      doc: Documented
+      ci: Continuous Integration
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ parameters:
     description: SSH fingerprint.
     type: string
     default: "37:64:7e:27:18:71:a0:50:c5:d3:bc:d0:04:1a:75:51"
-  triggered_by_bot:
-    default: false
-    description: Trigger publishing a release tag workflow.
-    type: boolean
+  triggered_flow:
+    default: "workflow-selector"
+    description: Workflow to be executed.
+    type: string
 
 executors:
   builder:
@@ -119,6 +119,12 @@ workflows:
 
   on-tag-release:
     jobs:
+      - build-n-test:
+          context:
+            - << pipeline.parameters.ctx_ci_cd >>
+            - << pipeline.parameters.ctx_dockerhub >>
+          filters:
+            <<: *filter-semantic-tag
       - publish-image:
           context:
             - << pipeline.parameters.ctx_ci_cd >>
@@ -126,5 +132,6 @@ workflows:
           filters:
             <<: *filter-semantic-tag
           image_tag: << pipeline.git.tag >>
+          requires: [ build-n-test ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,130 @@
+version: 2.1
+
+orbs:
+  vro: kohirens/version-release@3.1.0
+
+parameters:
+  ctx_ci_cd:
+    default: kohirens-automation
+    description: Secrets context
+    type: string
+  ctx_dockerhub:
+    default: kohirens-automation-dockerhub
+    description: Secrets context
+    type: string
+  ssh_finger:
+    description: SSH fingerprint.
+    type: string
+    default: "37:64:7e:27:18:71:a0:50:c5:d3:bc:d0:04:1a:75:51"
+  triggered_by_bot:
+    default: false
+    description: Trigger publishing a release tag workflow.
+    type: boolean
+
+executors:
+  builder:
+    docker:
+      - image: docker:20.10.14-git
+        auth:
+          username: ${DH_USER}
+          password: ${DH_PASS}
+    resource_class: small
+
+# Anchors
+
+default-env-vars: &default-env-vars
+    DH_IMG_REPO: "kohirens/circleci-aws-iac-tf"
+
+filter-semantic-tag: &filter-semantic-tag
+  tags:
+    only: /^v?\d+\.\d+\.\d+$/
+  branches:
+    ignore: /.*/
+
+jobs:
+    build-n-test:
+      executor: builder
+      environment:
+        <<: *default-env-vars
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run:
+            name: "Build Docker image"
+            command: |
+              docker build --rm --no-cache -t "${DH_IMG_REPO}" .
+        - run:
+            name: "Test Docker image"
+            command: |
+              docker run -it --rm "${DH_IMG_REPO}" aws --version
+              docker run -it --rm "${DH_IMG_REPO}" terraform -version
+
+    publish-image:
+      executor: builder
+      parameters:
+        image_tag:
+          default: "dev"
+          type: string
+      environment:
+        <<: *default-env-vars
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run:
+            name: Push Docker image
+            command: |
+              export DH_IMAGE="${DH_IMG_REPO}:<< parameters.image_tag >>"
+              echo "Building image ${DH_IMAGE}"
+              echo "${DH_PASS}" | docker login -u "${DH_USER}" --password-stdin
+              echo ""
+              echo ""
+              echo "Building ${DH_IMAGE}"
+              docker build --rm -t "${DH_IMAGE}" .
+              echo ""
+              echo ""
+              echo "Building ${DH_IMAGE}"
+              docker push "${DH_IMAGE}"
+              echo ""
+              echo ""
+              echo "Building ${DH_IMAGE}"
+              docker rmi "${DH_IMAGE}"
+
+workflows:
+  quality-control: # Run on all branches and PRs except main|auto-*
+    jobs:
+      - build-n-test:
+          context:
+            - << pipeline.parameters.ctx_ci_cd >>
+            - << pipeline.parameters.ctx_dockerhub >>
+          filters: { branches: { ignore: /main|auto-update-changelog/ } }
+
+  publish-changelog:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - equal: [webhook, << pipeline.trigger_source >>]
+    jobs:
+        - vro/publish-changelog:
+            context: << pipeline.parameters.ctx_ci_cd >>
+            ssh_finger: << pipeline.parameters.ssh_finger >>
+
+  publish-release-tag:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.triggered_by_bot >>
+    jobs:
+      - vro/tag-and-release:
+          context: << pipeline.parameters.ctx_dockerhub >>
+
+  on-tag-release:
+    jobs:
+      - publish-image:
+          context:
+            - << pipeline.parameters.ctx_ci_cd >>
+            - << pipeline.parameters.ctx_dockerhub >>
+          filters:
+            <<: *filter-semantic-tag
+          image_tag: << pipeline.git.tag >>
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vro: kohirens/version-release@3.1.0
+  vr: kohirens/version-release@3.1.0
 
 parameters:
   ctx_ci_cd:
@@ -98,24 +98,32 @@ workflows:
             - << pipeline.parameters.ctx_dockerhub >>
           filters: { branches: { ignore: /main|auto-update-changelog/ } }
 
+  workflow-selector:
+    when:
+      and:
+        - equal: ["workflow-selector", << pipeline.parameters.triggered_flow >>]
+        - equal: [ main, << pipeline.git.branch >> ]
+    jobs:
+      - vr/workflow-selector:
+          context: << pipeline.parameters.ctx_ci_cd >>
+          ssh_finger: << pipeline.parameters.ssh_finger >>
+
   publish-changelog:
     when:
       and:
-        - equal: [main, << pipeline.git.branch >>]
-        - equal: [webhook, << pipeline.trigger_source >>]
+        - equal: ["publish-changelog", << pipeline.parameters.triggered_flow >>]
     jobs:
-        - vro/publish-changelog:
-            context: << pipeline.parameters.ctx_ci_cd >>
-            ssh_finger: << pipeline.parameters.ssh_finger >>
+      - vr/publish-changelog:
+          context: << pipeline.parameters.ctx_ci_cd >>
+          ssh_finger: << pipeline.parameters.ssh_finger >>
 
   publish-release-tag:
     when:
       and:
-        - equal: [main, << pipeline.git.branch >>]
-        - << pipeline.parameters.triggered_by_bot >>
+        - equal: ["publish-release-tag", << pipeline.parameters.triggered_flow >>]
     jobs:
-      - vro/tag-and-release:
-          context: << pipeline.parameters.ctx_dockerhub >>
+      - vr/tag-and-release:
+          context: << pipeline.parameters.ctx_ci_cd >>
 
   on-tag-release:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Directories
+# -----------
+/.idea/
+
+# Files
+# -----

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kohirens/alpine-glibc:3.18.4-2.35-r1 AS base
+FROM kohirens/alpine-awscli:2.13.32 AS base
 
 ARG USER_NAME='circleci'
 ARG USER_UID='1000'
@@ -9,7 +9,6 @@ ENV TERRAFORM_DOWNLOAD_URL 'https://releases.hashicorp.com/terraform/1.6.3/terra
 ENV TFLINT_DOWNLOAD_URL 'https://github.com/wata727/tflint/releases/download/v0.53.0/tflint_linux_amd64.zip'
 ENV TFLINT_DOWNLOAD_URL 'https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip'
 ENV TERRAGRUNT_DOWNLOAD_URL 'https://github.com/gruntwork-io/terragrunt/releases/download/v0.53.0/terragrunt_linux_amd64'
-ENV AWSCLI_DOWNLOAD_URL 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip'
 
 WORKDIR /tmp
 
@@ -42,14 +41,9 @@ RUN curl --fail --silent -L -o /tmp/tflint.zip "${TFLINT_DOWNLOAD_URL}" \
  && rm -f /tmp/tflint.zip \
  && tflint
 
-RUN echo 'Install AWS CLI 2' \
- && wget -O "awscliv2.zip" "${AWSCLI_DOWNLOAD_URL}" \
- && unzip awscliv2.zip
+RUN aws --version
 
-RUN ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli \
- && aws --version
-
-#RUN rm -f /tmp/*
+RUN rm -rf /tmp/*
 
 # Add a non-root group and user.
 RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+    container:
+        image: "kohirens/circleci-aws-iac-tf:${BUILD_VER:-dev}"
+        build:
+            dockerfile: "Dockerfile"
+            context: "."
+            target: "dev"
+        tty: true

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# We'll use this script to manage starting and stopping this container gracefully.
+# It only takes up about 00.01 CPU % allotted to the container, you can verify
+# by running `docker stats` after you start a container that uses this as
+# as the CMD.
+
+set -e
+
+shutd () {
+    printf "Shutting down the container gracefully..."
+    # You can run clean commands here!
+    printf "done\n"
+}
+
+trap 'shutd' TERM
+
+echo "Starting up..."
+
+# Run non-blocking commands here
+
+echo "done"
+
+# This keeps the container running until it receives a signal to be stopped.
+# Also very low CPU usage.
+while :; do :; done & kill -STOP $! && wait $!


### PR DESCRIPTION
The Kohirens Alpine image has GLibC (vanilla) version 2.35-r1 installed/embedded to allow running apps like AWS CLI or NodeJS usable on smaller size Alpine images.

For more details visit https://hub.docker.com/repository/docker/kohirens/alpine-glibc/general